### PR TITLE
Timing fix for apa102

### DIFF
--- a/library/rainbowhat/apa102.py
+++ b/library/rainbowhat/apa102.py
@@ -17,6 +17,7 @@ pixels = [[0,0,0,BRIGHTNESS]] * NUM_PIXELS
 
 _gpio_setup = False
 _clear_on_exit = True
+_sleep_time = 0
 
 def _exit():
     if _clear_on_exit:
@@ -45,10 +46,10 @@ def _write_byte(byte):
     for x in range(8):
         GPIO.output(DAT, byte & 0b10000000)
         GPIO.output(CLK, 1)
-        time.sleep(0.0000005)
+        time.sleep(_sleep_time)
         byte <<= 1
         GPIO.output(CLK, 0)
-        time.sleep(0.0000005)
+        time.sleep(_sleep_time)
 
 # Emit exactly enough clock pulses to latch the small dark die APA102s which are weird
 # for some reason it takes 36 clocks, the other IC takes just 4 (number of pixels/2)
@@ -56,18 +57,18 @@ def _eof():
     GPIO.output(DAT, 0)
     for x in range(36):
         GPIO.output(CLK, 1)
-        time.sleep(0.0000005)
+        time.sleep(_sleep_time)
         GPIO.output(CLK, 0)
-        time.sleep(0.0000005)
+        time.sleep(_sleep_time)
 
 
 def _sof():
     GPIO.output(DAT,0)
     for x in range(32):
         GPIO.output(CLK, 1)
-        time.sleep(0.0000005)
+        time.sleep(_sleep_time)
         GPIO.output(CLK, 0)
-        time.sleep(0.0000005)
+        time.sleep(_sleep_time)
 
 
 def show():


### PR DESCRIPTION
Attempt to fix sleep timing issues across various Python versions.

See https://github.com/pimoroni/blinkt/pull/73 for more detailed information.

Relating to: https://github.com/pimoroni/mote-phat/issues/13
And: https://github.com/pimoroni/blinkt/issues/72

See also:

https://github.com/pimoroni/mote-phat/pull/14
https://github.com/pimoroni/blinkt/pull/73