### PR TITLE
Added learning card support to examples

### DIFF
--- a/examples/learning-cards/README.md
+++ b/examples/learning-cards/README.md
@@ -1,13 +1,20 @@
-## These examples go with the Learning Cards for the Rainbow HAT
+# These examples go with the Learning Cards for the Rainbow HAT
 
-Card 02 - 
-Card 03
-Card 04
-Card 05
-Card 06
-Card 07
-Card 08
-Card 09
-Card 10
-Project A
-Project B
+The learning cards are available as physical cards from shop.pimoroni.com, or as online tutorials at edu.pimoroni.com/rainbowhat
+
+They are meant to be self-led learning, with ideas and suggestions for extensions and debugging on each card.
+
+## The cards and their contents
+
+Card 01 is about installing the Rainbow HAT and attaching it to the Pi, so there is no example code.
+**Card 02** - displays text on the alphanumeric display 
+**Card 03** - takes a temperature reading and shows it on the display
+**Card 04** - takes a pressure reading and shows it on the display
+**Card 05** - makes a noise with the buzzer
+**Card 06** - lights up all or one of the rainbow LEDs
+**Card 07** - controls the lights above the buttons
+**Card 08** - uses the buttons to turn the lights on and off
+**Card 09** - uses the buttons to turn the rainbow LEDs on and off
+**Card 10** - uses the buttons to control colour and sound
+**Project A** - displays the temperature with coloured lights based on temperature
+**Project B** - light up the rainbow LEDs in a... rainbow.

--- a/examples/learning-cards/README.md
+++ b/examples/learning-cards/README.md
@@ -7,14 +7,25 @@ They are meant to be self-led learning, with ideas and suggestions for extension
 ## The cards and their contents
 
 Card 01 is about installing the Rainbow HAT and attaching it to the Pi, so there is no example code.
+
 **Card 02** - displays text on the alphanumeric display 
+
 **Card 03** - takes a temperature reading and shows it on the display
+
 **Card 04** - takes a pressure reading and shows it on the display
+
 **Card 05** - makes a noise with the buzzer
+
 **Card 06** - lights up all or one of the rainbow LEDs
+
 **Card 07** - controls the lights above the buttons
+
 **Card 08** - uses the buttons to turn the lights on and off
+
 **Card 09** - uses the buttons to turn the rainbow LEDs on and off
+
 **Card 10** - uses the buttons to control colour and sound
+
 **Project A** - displays the temperature with coloured lights based on temperature
+
 **Project B** - light up the rainbow LEDs in a... rainbow.

--- a/examples/learning-cards/README.md
+++ b/examples/learning-cards/README.md
@@ -1,0 +1,13 @@
+## These examples go with the Learning Cards for the Rainbow HAT
+
+Card 02 - 
+Card 03
+Card 04
+Card 05
+Card 06
+Card 07
+Card 08
+Card 09
+Card 10
+Project A
+Project B

--- a/examples/learning-cards/card02-displaying-text.py
+++ b/examples/learning-cards/card02-displaying-text.py
@@ -1,0 +1,11 @@
+# code from Learning Card 02 - Rainbow HAT
+
+# import the rainbowhat module
+import rainbowhat
+
+# adds the code to prepare to send the text to the display
+# with the word to display in double quotations
+rainbowhat.display.print_str("Test")
+
+# displays the word on the rainbow HAT
+rainbowhat.display.show()

--- a/examples/learning-cards/card03-temperature-reading.py
+++ b/examples/learning-cards/card03-temperature-reading.py
@@ -1,0 +1,13 @@
+# code from Learning Card 02 - Rainbow HAT
+
+# import the rainbowhat module
+import rainbowhat
+
+# create a variable to store the temperature reading in
+temperature = rainbowhat.weather.temperature()
+
+# sends the data from the reading to the display
+rainbowhat.display.print_float(temperature)
+
+# displays the data on the rainbow HAT
+rainbowhat.display.show()

--- a/examples/learning-cards/card04-pressure-reading.py
+++ b/examples/learning-cards/card04-pressure-reading.py
@@ -1,0 +1,13 @@
+# code from Learning Card 04 - Rainbow HAT
+
+# import the rainbowhat module
+import rainbowhat
+
+# create a variable to store the pressure reading in
+pres = rainbowhat.weather.pressure()
+
+# sends the data from the reading to the display
+rainbowhat.display.print_float(pres)
+
+# displays the data on the rainbow HAT
+rainbowhat.display.show()

--- a/examples/learning-cards/card05-musical-buzzer.py
+++ b/examples/learning-cards/card05-musical-buzzer.py
@@ -1,0 +1,7 @@
+# code from Learning Card 05 - Rainbow HAT
+
+# import the rainbowhat module
+import rainbowhat
+
+# sends a note and length of note to the buzzer
+rainbowhat.buzzer.midi_note(61, 2)

--- a/examples/learning-cards/card06-led-colours.py
+++ b/examples/learning-cards/card06-led-colours.py
@@ -1,0 +1,29 @@
+# code from Learning Card 06 - Rainbow HAT
+
+# import the rainbowhat and time modules
+import rainbowhat
+import time
+
+# set all LEDs to magenta at 0.1 brightness
+rainbowhat.rainbow.set_all(100, 10, 100, 0.1)
+
+# show all the changes to the LEDs
+rainbowhat.rainbow.show()
+
+# wait 2 seconds before doing the next step
+time.sleep(2)
+
+# set just pixel 3 to green at 0.1 brightness
+rainbowhat.rainbow.set_pixel(3, 0, 255, 0, 0.1)
+
+# show all the changes to the LEDs
+rainbowhat.rainbow.show()
+
+# wait 2 seconds before doing the next step
+time.sleep(2)
+
+# set all LEDs to no colour (off) at 0 brightness
+rainbowhat.rainbow.set_all(0, 0, 0, 0)
+
+# show all the changes to the LEDs
+rainbowhat.rainbow.show()

--- a/examples/learning-cards/card07-minileds.py
+++ b/examples/learning-cards/card07-minileds.py
@@ -1,0 +1,11 @@
+# code from Learning Card 07 - Rainbow HAT
+
+# import the rainbowhat and time modules
+import rainbowhat
+import time
+
+# set the first light above touch pad A to "on"
+rainbowhat.lights.rgb(1, 0, 0)
+
+# show all the changes to the lights
+rainbowhat.lights.show()

--- a/examples/learning-cards/card08-touch-buttons.py
+++ b/examples/learning-cards/card08-touch-buttons.py
@@ -19,3 +19,4 @@ def release(channel):
 
 # waits until a signal is received
 signal.pause()
+

--- a/examples/learning-cards/card08-touch-buttons.py
+++ b/examples/learning-cards/card08-touch-buttons.py
@@ -1,0 +1,21 @@
+# code from Learning Card 08 - Rainbow HAT
+
+# import the rainbowhat and signal modules
+import rainbowhat
+import signal
+
+# this section links a press on button A
+# to what to do when it happens
+@rainbowhat.touch.A.press()
+def touch_a(channel):
+    rainbowhat.lights.rgb(1, 0, 0)
+
+
+# this section links a letting go of any button
+# to what to do when it happens
+@rainbowhat.touch.release()
+def release(channel):
+    rainbowhat.lights.rgb(0, 0, 0)
+
+# waits until a signal is received
+signal.pause()

--- a/examples/learning-cards/card09-touchbutton-led.py
+++ b/examples/learning-cards/card09-touchbutton-led.py
@@ -1,0 +1,31 @@
+# code from Learning Card 09 - Rainbow HAT
+
+# import the rainbowhat and signal modules
+import rainbowhat
+import signal
+
+# this section links a press on button A
+# to what to do when it happens
+@rainbowhat.touch.A.press()
+def touch_a(channel):
+
+# this time we make the rainbow leds come on
+# as well as the button light
+    rainbowhat.lights.rgb(1, 0, 0)
+    rainbowhat.rainbow.set_pixel(3, 0, 255, 0, 0.1)
+    rainbowhat.rainbow.show()
+
+
+# this section links a letting go of any button
+# to what to do when it happens
+@rainbowhat.touch.release()
+def release(channel):
+
+# turn the button light off, and also
+# turn the rainbow led off
+    rainbowhat.lights.rgb(0, 0, 0)
+    rainbowhat.rainbow.set_pixel(3, 0, 255, 0, 0.1)
+    rainbowhat.rainbow.show()
+
+# waits until a signal is received
+signal.pause()

--- a/examples/learning-cards/card10-musical-touch.py
+++ b/examples/learning-cards/card10-musical-touch.py
@@ -1,0 +1,30 @@
+# code from Learning Card 10 - Rainbow HAT
+
+# import the rainbowhat and signal modules
+import rainbowhat
+import signal
+
+# this section links a press on button A
+# to what to do when it happens
+@rainbowhat.touch.A.press()
+def touch_a(channel):
+
+# this time we make the buzzer sound
+# as well as making the button light come on
+    rainbowhat.lights.rgb(1, 0, 0)
+    rainbowhat.buzzer.midi_note(65, 1)
+
+# add the same for button B
+@rainbowhat.touch.B.press()
+def touch_b(channel):
+    rainbowhat.lights.rgb(0, 1, 0)
+    rainbowhat.buzzer.midi_note(80, 1)
+
+# this section links a letting go of any button
+# to what to do when it happens
+@rainbowhat.touch.release()
+def release(channel):
+    rainbowhat.lights.rgb(0, 0, 0)
+
+# waits until a signal is received
+signal.pause()

--- a/examples/learning-cards/card10-musical-touch.py
+++ b/examples/learning-cards/card10-musical-touch.py
@@ -9,8 +9,8 @@ import signal
 @rainbowhat.touch.A.press()
 def touch_a(channel):
 
-# this time we make the buzzer sound
-# as well as making the button light come on
+    # this time we make the buzzer sound
+    # as well as making the button light come on
     rainbowhat.lights.rgb(1, 0, 0)
     rainbowhat.buzzer.midi_note(65, 1)
 
@@ -26,5 +26,7 @@ def touch_b(channel):
 def release(channel):
     rainbowhat.lights.rgb(0, 0, 0)
 
+    
 # waits until a signal is received
 signal.pause()
+

--- a/examples/learning-cards/project01.py
+++ b/examples/learning-cards/project01.py
@@ -1,0 +1,29 @@
+# code from Project 01 - Rainbow HAT
+
+# import the rainbowhat and time modules
+import rainbowhat
+import time
+
+# a while True loop keeps doing things until interrupted
+while True:
+
+    # take the temperature and show it on the display
+    temperature = rainbowhat.weather.temperature()
+    rainbowhat.display.print_float(temperature)
+    rainbowhat.display.show()
+
+    # if the temperature is less than 25, just use blue
+    if temperature < 25:
+        blue = 255 - (temperature * 6)
+        rainbowhat.rainbow.set_all(0, 0, blue, brightness=0.1)
+        rainbowhat.rainbow.show()
+
+    # if the temperature is more than 25, use green and red
+    # combined to make shades of red and orange
+    else:
+        green = 255 - (temperature * 6)
+        rainbowhat.rainbow.set_all(255, green, 0, brightness=0.1)
+        rainbowhat.rainbow.show()
+
+    # wait 10 seconds before taking the temperature again
+    time.sleep(10)

--- a/examples/learning-cards/project02.py
+++ b/examples/learning-cards/project02.py
@@ -18,3 +18,4 @@ rainbowhat.rainbow.show()
 time.sleep(1)
 
 # continue the pattern to add the other colours of the rainbow 
+

--- a/examples/learning-cards/project02.py
+++ b/examples/learning-cards/project02.py
@@ -1,0 +1,20 @@
+# import the rainbowhat and time modules
+import rainbowhat
+import time
+
+# set the first LED to red, show it, and wait 1 second before continuing
+rainbowhat.rainbow.set_pixel(6, 255, 0, 0, 0.1)
+rainbowhat.rainbow.show()
+time.sleep(1)
+
+# set the second LED to orange, show it, and wait 1 second before continuing
+rainbowhat.rainbow.set_pixel(5, 255, 100, 0, 0.1)
+rainbowhat.rainbow.show()
+time.sleep(1)
+
+# set the third LED to yellow, and so on.
+rainbowhat.rainbow.set_pixel(4, 255, 255, 0, 0.1)
+rainbowhat.rainbow.show()
+time.sleep(1)
+
+# continue the pattern to add the other colours of the rainbow 


### PR DESCRIPTION
All examples from the learning cards are in a separate folder.
A new README file for the learning materials was created.
This is support material, not stand-alone and goes with the RainbowHAT Learning Cards.