### PR TITLE
Changed line 221 in alphanum4.py to correct 0 to -1 '----' bug

### DIFF
--- a/library/rainbowhat/alphanum4.py
+++ b/library/rainbowhat/alphanum4.py
@@ -218,9 +218,9 @@ class AlphaNum4(HT16K33.HT16K33):
         Decimal digits is the desired number of digits after the decimal point.
 
         """
-         if value < 0 and value > -1:
+        if value < 0 and value > -1:
  38         decimal_digits = 3 - len(str(int(value)))
- 39      else:
+ 39     else:
             decimal_digits = 4 - len(str(int(value)))
         format_string = '{{0:0.{0}F}}'.format(decimal_digits)
         self.print_number_str(format_string.format(value), justify_right)

--- a/library/rainbowhat/alphanum4.py
+++ b/library/rainbowhat/alphanum4.py
@@ -218,7 +218,10 @@ class AlphaNum4(HT16K33.HT16K33):
         Decimal digits is the desired number of digits after the decimal point.
 
         """
-        decimal_digits = 4 - len(str(int(value)))
+         if value < 0 and value > -1:
+ 38         decimal_digits = 3 - len(str(int(value)))
+ 39      else:
+            decimal_digits = 4 - len(str(int(value)))
         format_string = '{{0:0.{0}F}}'.format(decimal_digits)
         self.print_number_str(format_string.format(value), justify_right)
 


### PR DESCRIPTION
I found a funny bug in the @pimoroni Rainbow hat python library, when display.print_float is passed a value between 0 and -1 '----' is displayed. I have traced the bug to a string with a length of 5 chars is passed to print_number_str and trips the if statement to display the '----'
My work around is to test the value passed to display.print_float before it is formatted and if the value falls between 0 and -1 a 3 is used instead of 4 when adjusting the length of the output string. 

code to replace line 221

 ```
if value < 0 and value > -1:
            decimal_digits = 3 - len(str(int(value)))
       else:
            decimal_digits = 4 - len(str(int(value)))
```


example code

```
import rainbowhat
rainbowhat.display.print_float(-0.1)
rainbowhat.display.show()
```

code output before code correction
'----'
and afterwards
-0.1




